### PR TITLE
Issues/KUI-1644: update logics for year list headings

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -120,8 +120,7 @@ module.exports = {
         'All the administrative course instances that was included in the course offering. Students are admitted to an administrative course instance. Degree program students and non-programme students are admitted to different administrative course instances but may be educated in the same course offering. A course offering is thereby the practical realisation of the course with a common start date, common pace, common timetable etc. for all students. Several administrative course instances are grouped to one course offering'
     },
 
-    no_course_analysis:
-      'When the course analysis has been published, the course data, course memo and course syllabus are displayed.',
+    no_course_analysis: 'Course analysis not published',
     no_added: 'No information inserted',
 
     syllabusLink: { header: 'Course syllabus', no_added_doc: 'No course syllabus added' },
@@ -140,7 +139,7 @@ module.exports = {
     course_info_title: 'Course information',
     regulated_link: '“Guidelines on course evaluation and course analysis”. ',
     info_text: {
-      0: 'On this page, you can see how the course has developed over time. For each course offering, course data is displayed (number of registered students and course results, along with planned changes for the next session). ',
+      0: "On this page, you can track the course's development over time. Once the course analysis is published, data for each course offering is displayed, including the number of registered students, course results, and planned improvements for the next session. ",
       1: 'All course syllabuses and course memos are shown on the page ',
       2: 'The information can help prospective, current, and former students with course selection, or to follow up on their own participation. Teachers, course coordinators, examiners, program directors, and others can use the page as a resource for course development.'
     },

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -119,7 +119,7 @@ module.exports = {
         'Alla kurstillfällen som ingick i kursomgången. Studenter är antagna till ett kurstillfälle. Programstudenter, betalande studenter och fristående studenter antas till olika kurstillfällen men kan utbildas i samma kursomgång. Kurstillfällen ska alltså grupperas ihop till en kursomgång. Kursomgången är ett praktiskt genomförande av en kurs. Kursomgången har en gemensam starttidpunkt, gemensam kurstakt och normalt gemensam undervisning för en studentgrupp. Schemat läggs per kursomgång, kurs-PM utformas per kursomgång och kursanalys genomförs per kursomgång.'
     },
 
-    no_course_analysis: 'När kursanalysen är publicerad visas kursdata, kurs-PM och kursplan.',
+    no_course_analysis: 'Kursanalys ej publicerad',
     no_added: 'Ingen information tillagd',
 
     syllabusLink: { header: 'Kursplan', no_added_doc: 'Ingen kursplan tillagd' },
@@ -138,7 +138,7 @@ module.exports = {
     course_info_title: 'Kursinformation',
     regulated_link: '”Riktlinje om kursvärdering och kursanalys”. ',
     info_text: {
-      0: 'På denna sida kan du se hur kursen utvecklats över tid. För varje kurstillfälle visas kursdata (examination, antal registrerade studenter och resultat på kurs tillsammans med planerade förändringar till nästa kurstillfälle). ',
+      0: 'På denna sida kan du följa hur kursen har utvecklats över tid. När kursanalysen har publicerats visas kursdata för varje kurstillfälle, inklusive examination, antal registrerade studenter, kursresultat samt planerade förändringar inför nästa kurstillfälle. ',
       1: 'Alla kursplaner och publicerade kurs-PM visas på sidan ',
       2: 'Presumtiva, nuvarande, och tidigare studenter kan ta del av informationen som hjälp vid kursval, eller för att följa upp sitt eget deltagande. Lärare, kursansvariga, examinatorer, programansvariga m.fl. kan använda sidan som ett stöd vid kursutveckling.'
     },

--- a/public/css/kursutveckling-web.scss
+++ b/public/css/kursutveckling-web.scss
@@ -265,6 +265,10 @@ body.use-personal-menu {
     min-width: 7em;
     max-width: 7em;
   }
+
+  .grade-col {
+    overflow-wrap: normal;
+  }
 }
 
 .alterationText {

--- a/public/js/app/components/AnalysisList/ResultsSection.tsx
+++ b/public/js/app/components/AnalysisList/ResultsSection.tsx
@@ -33,7 +33,9 @@ const ResultsSection: React.FC<ResultsSectionContentProps> = ({ analysis }) => {
             </Row>
             {Object.entries(gradingDistribution).map(([grade, count]) => (
               <Row key={grade}>
-                <Col xs="2">{grade}</Col>
+                <Col xs="2" className="grade-col">
+                  {grade}
+                </Col>
                 <Col xs="8">
                   <span>{count}</span>
                 </Col>

--- a/public/js/app/components/LinkToValidSyllabusPdf/index.tsx
+++ b/public/js/app/components/LinkToValidSyllabusPdf/index.tsx
@@ -49,7 +49,7 @@ const LinkToValidSyllabusPdf: React.FC<{
 
   const syllabusPeriod = syllabusPeriods[syllabusPeriodStart]
   const startTermName = formatSemesterName(syllabusPeriodStart, courseShortSemester)
-  const endTermName = formatSemesterName(syllabusPeriod.endDate || '', courseShortSemester)
+  const endTermName = formatSemesterName(syllabusPeriod?.endDate || '', courseShortSemester)
   const syllabusLabel = `${header} ${courseCode} ( ${startTermName} - ${endTermName} )`
 
   return (

--- a/test/mocks/transformedAnalysisData.js
+++ b/test/mocks/transformedAnalysisData.js
@@ -141,7 +141,6 @@ const transformedAnalysisDataFromAdminWeb = {
       __v: 0
     }
   ],
-  2016: [],
   2017: [
     {
       _id: 'SF1624VT2017_1_2',
@@ -286,16 +285,10 @@ const transformedAnalysisDataFromAdminWeb = {
       analysisName: 'CMATD1 m.fl. ( Startdatum 2019-10-28, Svenska )',
       __v: 0
     }
-  ],
-  2020: [],
-  2021: []
+  ]
 }
 
 const transformedAnalysisDataFromCanvas = {
-  2019: [],
-  2020: [],
-  2021: [],
-  2022: [],
   2023: [
     {
       _id: '673ae58e7d5093b55e7dc88a',


### PR DESCRIPTION
Adding the logic for what years to show in _Kursens utveckling_. This by adding the function `fillAndSortYears` which ensures the list of years is complete by:

1. Show the current year if data does not exist at all or exists wihtin the last two years
2. Show all years between max and min years having data (incl. even years missing data)

Examples:
Latest year with data is 2023:
http://localhost:3000/kursutveckling/FCB3001

Latest year with data is 2024:
http://localhost:3000/kursutveckling/KH1242

Latest year with data is 2019:
http://localhost:3000/kursutveckling/HL2027

Has no data:
http://localhost:3000/kursutveckling/SF2743

Data is missing for 2020, but exists for 2019 and 2021:
http://localhost:3000/kursutveckling/SF1626?l=sv