### PR TITLE
KUI-1870: reintroduce aria-labels if meaningful

### DIFF
--- a/public/js/app/components/ActiveOrDisabledLink/ActiveOrDisabledLink.test.tsx
+++ b/public/js/app/components/ActiveOrDisabledLink/ActiveOrDisabledLink.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import ActiveOrDisabledLink from './index'
+
+describe('ActiveOrDisabledLink', () => {
+  it('renders an active link with the correct href and title', () => {
+    const href = 'https://example.com'
+    const linkTitle = 'Active Link'
+    const isPdf = false
+
+    render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf={isPdf} />)
+
+    const linkElement = screen.getByText(linkTitle)
+
+    expect(linkElement.tagName).toBe('A')
+    expect(linkElement).toHaveAttribute('href', href)
+    expect(linkElement).toHaveAttribute('title', linkTitle)
+  })
+
+  it('renders a disabled link as a span with italic text', () => {
+    const linkTitle = 'Disabled Link'
+    render(<ActiveOrDisabledLink linkTitle={linkTitle} disabled />)
+
+    const italicElement = screen.getByText(linkTitle)
+    expect(italicElement.tagName).toBe('I')
+
+    const spanElement = italicElement.parentElement
+
+    expect(spanElement.tagName).toBe('SPAN')
+    expect(spanElement).toHaveClass('disabled-link')
+  })
+
+  describe('when PDF is true', () => {
+    it('sets prefixed linkTitle as aria-label if no ariaLabel is given', () => {
+      const href = '/file.pdf'
+      const linkTitle = 'PDF File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).toHaveAttribute('aria-label', `PDF ${linkTitle}`)
+    })
+
+    it('sets prefixed ariaLabel as aria-label', () => {
+      const href = '/file.pdf'
+      const linkTitle = 'PDF File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).toHaveAttribute('aria-label', `PDF ${linkTitle}`)
+    })
+
+    it('sets target and rel attributes for PDF links', () => {
+      const href = '/file.pdf'
+      const linkTitle = 'PDF File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).toHaveAttribute('target', '_blank')
+      expect(linkElement).toHaveAttribute('rel', 'noreferrer')
+    })
+
+    it('applies "pdf-link" class for PDF links', () => {
+      const href = '/file.pdf'
+      const linkTitle = 'PDF File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).toHaveClass('pdf-link')
+    })
+
+    it('combines custom class with "pdf-link" class', () => {
+      const href = '/file.pdf'
+      const linkTitle = 'PDF File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).toHaveClass('pdf-link')
+      expect(linkElement).toHaveClass('link')
+    })
+  })
+
+  describe('when PDF is false', () => {
+    it('does not set linkTitle as aria-label if no ariaLabel is given', () => {
+      const href = '/file'
+      const linkTitle = 'Regular File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).not.toHaveAttribute('aria-label')
+    })
+
+    it('does set aria-label if ariaLabel is provided', () => {
+      const href = '/file'
+      const linkTitle = 'Regular File'
+      const ariaLabel = 'Custom Label'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} ariaLabel={ariaLabel} />)
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).toHaveAttribute('aria-label', ariaLabel)
+    })
+
+    it('does not set target and rel attributes', () => {
+      const href = '/file'
+      const linkTitle = 'Regular File'
+      render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} />)
+
+      const linkElement = screen.getByText(linkTitle)
+      expect(linkElement).not.toHaveAttribute('target')
+      expect(linkElement).not.toHaveAttribute('rel')
+    })
+  })
+
+  it('renders with className "link" even if none is provided', () => {
+    const href = '/default'
+    const linkTitle = 'Default Class Link'
+    render(<ActiveOrDisabledLink href={href} linkTitle={linkTitle} />)
+
+    const linkElement = screen.getByText(linkTitle)
+    expect(linkElement).toHaveClass('link')
+  })
+})

--- a/public/js/app/components/ActiveOrDisabledLink/index.tsx
+++ b/public/js/app/components/ActiveOrDisabledLink/index.tsx
@@ -3,20 +3,47 @@ import React from 'react'
 const ActiveOrDisabledLink: React.FC<{
   href?: string
   linkTitle: string
-  className?: string
   disabled?: boolean
-}> = ({ href, linkTitle, className = '', disabled = false }) => {
-  const linkClassName = `link ${className} ${disabled ? 'disabled-link' : ''}`.trim()
+  isPdf?: boolean
+  ariaLabel?: string
+}> = ({ href, linkTitle, disabled = false, isPdf = false, ariaLabel: ariaLabelOverride = undefined }) => {
+  const classNames = getClassNames(disabled, isPdf)
+  const pdfOptions = getPdfOptions(isPdf)
+  const ariaLabel = getAriaLabel(ariaLabelOverride, isPdf, linkTitle)
 
   return disabled ? (
-    <span className={linkClassName}>
+    <span className={classNames}>
       <i>{linkTitle}</i>
     </span>
   ) : (
-    <a href={href} className={linkClassName} target="_blank" rel="noreferrer" title={linkTitle}>
+    <a title={linkTitle} href={href} className={classNames} {...pdfOptions} {...ariaLabel}>
       {linkTitle}
     </a>
   )
 }
 
 export default ActiveOrDisabledLink
+
+const getClassNames = (disabled: boolean, isPdf: boolean) => {
+  const baseClass = 'link'
+  const disabledClass = disabled ? 'disabled-link' : ''
+  const pdfClass = isPdf ? 'pdf-link' : ''
+
+  return [baseClass, disabledClass, pdfClass].filter(Boolean).join(' ').trim()
+}
+
+const getPdfOptions = (isPdf: boolean) => {
+  if (!isPdf) return {}
+
+  return {
+    target: '_blank',
+    rel: 'noreferrer'
+  }
+}
+
+const getAriaLabel = (ariaLabelOverride?: string, isPdf?: boolean, linkTitle?: string) => {
+  if (!ariaLabelOverride && !isPdf) return {}
+
+  const label = ariaLabelOverride ?? linkTitle
+  return { 'aria-label': isPdf ? `PDF ${label}` : label }
+}

--- a/public/js/app/components/LinkToCourseAnalysis/index.tsx
+++ b/public/js/app/components/LinkToCourseAnalysis/index.tsx
@@ -17,7 +17,7 @@ const LinkToCourseAnalysis: React.FC<{
   const linkTitle = `${header} ${courseCode}${validFrom ? `: ${validFrom}` : ''}`
   const href = `${storageUri}${analysisFileName}`
 
-  return <ActiveOrDisabledLink href={href} className="pdf-link" linkTitle={linkTitle} />
+  return <ActiveOrDisabledLink href={href} linkTitle={linkTitle} isPdf />
 }
 
 export default LinkToCourseAnalysis

--- a/public/js/app/components/LinkToValidSyllabusPdf/index.tsx
+++ b/public/js/app/components/LinkToValidSyllabusPdf/index.tsx
@@ -56,7 +56,7 @@ const LinkToValidSyllabusPdf: React.FC<{
     <ActiveOrDisabledLink
       href={`${SYLLABUS_URL}${courseCode}-${syllabusPeriodStart}.pdf?lang=${userLang}`}
       linkTitle={syllabusLabel}
-      className="pdf-link"
+      isPdf
     />
   )
 }

--- a/public/js/app/components/LinksToCourseMemos/index.tsx
+++ b/public/js/app/components/LinksToCourseMemos/index.tsx
@@ -72,12 +72,7 @@ const LinksToCourseMemos: React.FC<{
         <ActiveOrDisabledLink key={index} linkTitle={noAddedDoc} disabled />
       ))}
       {Object.entries(pdfMemos).map(([fileName]) => (
-        <ActiveOrDisabledLink
-          key={fileName}
-          className="pdf-link"
-          href={`${memoStorageUri}${fileName}`}
-          linkTitle={memoTitle}
-        />
+        <ActiveOrDisabledLink key={fileName} href={`${memoStorageUri}${fileName}`} linkTitle={memoTitle} isPdf />
       ))}
       {Object.entries(webMemos).map(([endPoint]) => (
         <ActiveOrDisabledLink

--- a/public/js/app/components/MemoTable.jsx
+++ b/public/js/app/components/MemoTable.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { seasonStr } from '../util/helpers'
 import Table from './Table'
+import ActiveOrDisabledLink from './ActiveOrDisabledLink'
 
 const createRow = (translation, courseMemo) => {
   const { semester, courseOffering, isPdf, memoName, memoVersionsAndUrls } = courseMemo
@@ -11,15 +12,12 @@ const createRow = (translation, courseMemo) => {
       {memoName && <li key={memoName}>{memoName + ':'}</li>}
       {memoVersionsAndUrls.map((memoEntry, index) => (
         <li key={index}>
-          <a
-            aria-label={`${isPdf ? 'PDF ' : ''}${memoEntry.ariaLabel}`}
+          <ActiveOrDisabledLink
+            linkTitle={memoEntry.name}
+            isPdf={isPdf}
             href={memoEntry.url}
-            target={isPdf ? '_blank' : null}
-            rel={isPdf ? 'noreferrer' : null}
-            className={isPdf ? 'pdf-link' : null}
-          >
-            {memoEntry.name}
-          </a>
+            ariaLabel={memoEntry.ariaLabel}
+          />
           {memoEntry.latest ? ` (${translation.label_latest_version})` : ''}
         </li>
       ))}


### PR DESCRIPTION
This PR
- refactors ActiveOrDisabledLink so that it is usable in more scenarios
- makes use of ActiveOrDisabledLink in MemoTable
- reintroduces PDF-prefixed aria-labels